### PR TITLE
better default for encoding

### DIFF
--- a/src/xrp/__init__.py
+++ b/src/xrp/__init__.py
@@ -22,7 +22,7 @@ def parse(text):
     return XFileView(XParser(text_iterable=text))
 
 
-def parse_file(file, encoding=''):
+def parse_file(file, encoding=None):
     """ Reads the file's contents and returns the output of parse(text=contents).
     """
     with open(file, encoding=encoding) as f:


### PR DESCRIPTION
With '' as the default encoding, it crashes when no encoding is specified: `LookupError: unknown encoding:`

With 'None', it doesn't crash, and seems to open most Xresources files happily.